### PR TITLE
Add card-style UI for bookkeeping

### DIFF
--- a/One/README.md
+++ b/One/README.md
@@ -1,4 +1,4 @@
-# One music App
+# iOS 记账 App
 
-### 一、One Music
+此项目展示了一个简易的记账应用，界面设计借鉴了苹果钱包中 Apple Card/Apple Savings 的风格。主页包含卡片式的余额展示以及支出列表，便于用户直观查看每日消费情况。
 

--- a/One/Views/Home/CardView.swift
+++ b/One/Views/Home/CardView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import Charts
+
+struct CardView: View {
+    var balance: Double
+    var dailyBalances: [DailyBalance]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("总余额")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text("¥ \(String(format: "%.2f", balance))")
+                .font(.largeTitle)
+                .bold()
+                .foregroundColor(.white)
+
+            Chart(dailyBalances) { item in
+                LineMark(
+                    x: .value("Day", item.day),
+                    y: .value("Amount", item.amount)
+                )
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(.white)
+            }
+            .chartYAxis(.hidden)
+            .chartXAxis(.hidden)
+            .frame(height: 100)
+
+            Spacer(minLength: 0)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, minHeight: 180, maxHeight: 220)
+        .background(
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    Color(red: 0.95, green: 0.67, blue: 0.33),
+                    Color(red: 0.94, green: 0.47, blue: 0.48),
+                    Color(red: 0.79, green: 0.49, blue: 0.98)
+                ]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .cornerRadius(25)
+        .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 4)
+    }
+}
+
+#Preview {
+    CardView(balance: 1024.0, dailyBalances: [
+        DailyBalance(day: "1", amount: 1000),
+        DailyBalance(day: "2", amount: 1100)
+    ])
+}

--- a/One/Views/Home/HomeView.swift
+++ b/One/Views/Home/HomeView.swift
@@ -40,17 +40,6 @@ struct HomeView: View {
         Expense(name: "电影", amount: 15.0, category: .entertainment)
     ]
 
-    @State private var animateGradient = false
-
-    private func randomGradient() -> RadialGradient {
-        let colors = [Color.purple, Color.orange, Color.yellow, Color.green, Color.blue, Color.pink].shuffled()
-        return RadialGradient(
-            gradient: Gradient(colors: colors + [colors.first!]),
-            center: UnitPoint(x: Double.random(in: 0...1), y: Double.random(in: 0...1)),
-            startRadius: 100,
-            endRadius: 500
-        )
-    }
 
     var body: some View {
         NavigationStack {
@@ -71,36 +60,7 @@ struct HomeView: View {
                     }
                 }
 
-                ZStack {
-                    RoundedRectangle(cornerRadius: 25)
-                        .fill(randomGradient())
-                        .frame(height: 220)
-                        .onAppear {
-                            withAnimation(Animation.linear(duration: 6).repeatForever(autoreverses: true)) {
-                                animateGradient.toggle()
-                            }
-                        }
-
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("¥ \(String(format: "%.2f", balance))")
-                            .font(.title2)
-                            .bold()
-                            .foregroundColor(.white)
-
-                        Chart(dailyBalances) { item in
-                            LineMark(
-                                x: .value("Day", item.day),
-                                y: .value("Amount", item.amount)
-                            )
-                            .interpolationMethod(.catmullRom)
-                            .foregroundStyle(.white)
-                        }
-                        .chartYAxis(.hidden)
-                        .chartXAxis(.hidden)
-                        .frame(height: 120)
-                    }
-                    .padding()
-                }
+                CardView(balance: balance, dailyBalances: dailyBalances)
 
                 Text("支出记录")
                     .font(.headline)


### PR DESCRIPTION
## Summary
- redesign README for the bookkeeping app
- create `CardView` implementing Apple Card–inspired gradient card with balance and chart
- show `CardView` in `HomeView`
- fix compile errors by importing Charts and using system colors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f432c82c8832e8dda7d8143672ad4